### PR TITLE
Add FastAPI server with basic real estate support features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# my-project
+# Real Estate Support App
+
+This project provides a simple FastAPI server that offers basic support functions after purchasing real estate.
+
+## Features
+- List real estate professionals and schedule appointments
+- Browse informational columns on maintaining property value and tax deductions
+- Explore communities and post messages
+
+## Development
+1. Install dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```
+   uvicorn app.main:app --reload
+   ```
+3. Run tests:
+   ```
+   pytest
+   ```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,81 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+from datetime import datetime
+
+app = FastAPI(title="Real Estate Support API")
+
+class Professional(BaseModel):
+    id: int
+    name: str
+    profession: str
+    rating: float
+
+class Appointment(BaseModel):
+    professional_id: int
+    client_name: str
+    scheduled_time: datetime
+
+class Column(BaseModel):
+    id: int
+    title: str
+    content: str
+
+class Community(BaseModel):
+    id: int
+    name: str
+    description: str
+    messages: List[str] = []
+
+professionals = [
+    Professional(id=1, name="田中不動産", profession="Real Estate Agent", rating=4.5),
+    Professional(id=2, name="佐藤税理士", profession="Tax Advisor", rating=4.7),
+]
+
+columns = [
+    Column(id=1, title="住宅ローン控除について", content="住宅ローン控除の基本を解説します。"),
+    Column(id=2, title="資産価値を高めるリフォーム", content="リフォームのポイントを紹介します。"),
+]
+
+communities = [
+    Community(id=1, name="リフォーム情報交換", description="リフォームのアイデアを共有するコミュニティ"),
+    Community(id=2, name="資産運用", description="不動産の資産運用について議論するコミュニティ"),
+]
+
+appointments: List[Appointment] = []
+
+@app.get("/professionals", response_model=List[Professional])
+def list_professionals():
+    return professionals
+
+class AppointmentRequest(BaseModel):
+    client_name: str
+    scheduled_time: datetime
+
+@app.post("/professionals/{professional_id}/appointments", response_model=Appointment, status_code=201)
+def create_appointment(professional_id: int, request: AppointmentRequest):
+    professional = next((p for p in professionals if p.id == professional_id), None)
+    if not professional:
+        raise HTTPException(status_code=404, detail="Professional not found")
+    appointment = Appointment(professional_id=professional_id, client_name=request.client_name, scheduled_time=request.scheduled_time)
+    appointments.append(appointment)
+    return appointment
+
+@app.get("/columns", response_model=List[Column])
+def list_columns():
+    return columns
+
+@app.get("/communities", response_model=List[Community])
+def list_communities():
+    return communities
+
+class MessageRequest(BaseModel):
+    message: str
+
+@app.post("/communities/{community_id}/messages", status_code=201)
+def post_message(community_id: int, request: MessageRequest):
+    community = next((c for c in communities if c.id == community_id), None)
+    if not community:
+        raise HTTPException(status_code=404, detail="Community not found")
+    community.messages.append(request.message)
+    return {"status": "ok", "community_id": community_id, "message": request.message}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from app.main import app, professionals, appointments
+
+client = TestClient(app)
+
+def test_list_professionals():
+    response = client.get("/professionals")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == len(professionals)
+    assert data[0]["name"] == professionals[0].name
+
+def test_create_appointment():
+    appointments.clear()
+    payload = {"client_name": "山田太郎", "scheduled_time": "2025-01-01T10:00:00"}
+    response = client.post("/professionals/1/appointments", json=payload)
+    assert response.status_code == 201
+    assert len(appointments) == 1
+    assert appointments[0].client_name == "山田太郎"
+
+def test_list_columns():
+    response = client.get("/columns")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_list_communities_and_post_message():
+    response = client.get("/communities")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    message = {"message": "こんにちは"}
+    response_post = client.post("/communities/1/messages", json=message)
+    assert response_post.status_code == 201


### PR DESCRIPTION
## Summary
- implement FastAPI app with endpoints for professionals, columns, communities and appointments
- add tests covering basic API behavior
- document usage and setup instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6895be536b1c8320a2e0f67d30a163f3