### PR TITLE
Add static demo frontend to real estate support app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# my-project
+# Real Estate Support App
+
+This project provides a simple FastAPI server that offers basic support functions after purchasing real estate.
+
+## Features
+- List real estate professionals and schedule appointments
+- Browse informational columns on maintaining property value and tax deductions
+- Explore communities and post messages
+
+## Development
+1. Install dependencies:
+   ```
+   pip install -r requirements.txt
+   ```
+2. Run the server and open the demo site at http://localhost:8000:
+   ```
+   uvicorn app.main:app --reload
+   ```
+3. Run tests:
+   ```
+   pytest
+   ```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from typing import List
+from datetime import datetime
+from pathlib import Path
+
+app = FastAPI(title="Real Estate Support API")
+
+class Professional(BaseModel):
+    id: int
+    name: str
+    profession: str
+    rating: float
+
+class Appointment(BaseModel):
+    professional_id: int
+    client_name: str
+    scheduled_time: datetime
+
+class Column(BaseModel):
+    id: int
+    title: str
+    content: str
+
+class Community(BaseModel):
+    id: int
+    name: str
+    description: str
+    messages: List[str] = []
+
+professionals = [
+    Professional(id=1, name="田中不動産", profession="Real Estate Agent", rating=4.5),
+    Professional(id=2, name="佐藤税理士", profession="Tax Advisor", rating=4.7),
+]
+
+columns = [
+    Column(id=1, title="住宅ローン控除について", content="住宅ローン控除の基本を解説します。"),
+    Column(id=2, title="資産価値を高めるリフォーム", content="リフォームのポイントを紹介します。"),
+]
+
+communities = [
+    Community(id=1, name="リフォーム情報交換", description="リフォームのアイデアを共有するコミュニティ"),
+    Community(id=2, name="資産運用", description="不動産の資産運用について議論するコミュニティ"),
+]
+
+appointments: List[Appointment] = []
+
+@app.get("/professionals", response_model=List[Professional])
+def list_professionals():
+    return professionals
+
+class AppointmentRequest(BaseModel):
+    client_name: str
+    scheduled_time: datetime
+
+@app.post("/professionals/{professional_id}/appointments", response_model=Appointment, status_code=201)
+def create_appointment(professional_id: int, request: AppointmentRequest):
+    professional = next((p for p in professionals if p.id == professional_id), None)
+    if not professional:
+        raise HTTPException(status_code=404, detail="Professional not found")
+    appointment = Appointment(professional_id=professional_id, client_name=request.client_name, scheduled_time=request.scheduled_time)
+    appointments.append(appointment)
+    return appointment
+
+@app.get("/columns", response_model=List[Column])
+def list_columns():
+    return columns
+
+@app.get("/communities", response_model=List[Community])
+def list_communities():
+    return communities
+
+class MessageRequest(BaseModel):
+    message: str
+
+@app.post("/communities/{community_id}/messages", status_code=201)
+def post_message(community_id: int, request: MessageRequest):
+    community = next((c for c in communities if c.id == community_id), None)
+    if not community:
+        raise HTTPException(status_code=404, detail="Community not found")
+    community.messages.append(request.message)
+    return {"status": "ok", "community_id": community_id, "message": request.message}
+
+
+# Serve static frontend
+BASE_DIR = Path(__file__).resolve().parent
+app.mount("/", StaticFiles(directory=BASE_DIR / "static", html=True), name="static")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>不動産サポートアプリ</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    section { margin-bottom: 2rem; }
+    form { margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>不動産サポートアプリ</h1>
+  <section id="professionals">
+    <h2>専門家一覧</h2>
+    <ul id="pro-list"></ul>
+  </section>
+  <section id="columns">
+    <h2>コラム</h2>
+    <ul id="column-list"></ul>
+  </section>
+  <section id="communities">
+    <h2>コミュニティ</h2>
+    <ul id="community-list"></ul>
+  </section>
+
+  <script>
+  async function loadData() {
+    const proRes = await fetch('/professionals');
+    const professionals = await proRes.json();
+    const proList = document.getElementById('pro-list');
+    professionals.forEach(pro => {
+      const li = document.createElement('li');
+      li.textContent = `${pro.name} (${pro.profession}) 評価: ${pro.rating}`;
+      const form = document.createElement('form');
+      form.innerHTML = `
+        <input name="name" placeholder="お名前" required />
+        <input name="time" type="datetime-local" required />
+        <button type="submit">予約</button>
+      `;
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const name = form.querySelector('input[name="name"]').value;
+        const time = form.querySelector('input[name="time"]').value;
+        await fetch(`/professionals/${pro.id}/appointments`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ client_name: name, scheduled_time: time })
+        });
+        alert('予約しました');
+        form.reset();
+      });
+      li.appendChild(form);
+      proList.appendChild(li);
+    });
+
+    const colRes = await fetch('/columns');
+    const columns = await colRes.json();
+    const colList = document.getElementById('column-list');
+    columns.forEach(col => {
+      const li = document.createElement('li');
+      li.textContent = col.title;
+      colList.appendChild(li);
+    });
+
+    const commRes = await fetch('/communities');
+    const communities = await commRes.json();
+    const commList = document.getElementById('community-list');
+    communities.forEach(comm => {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>${comm.name}</strong>: ${comm.description}`;
+      const form = document.createElement('form');
+      form.innerHTML = `
+        <input name="message" placeholder="メッセージ" required />
+        <button type="submit">投稿</button>
+      `;
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const msg = form.querySelector('input[name="message"]').value;
+        await fetch(`/communities/${comm.id}/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: msg })
+        });
+        alert('投稿しました');
+        form.reset();
+      });
+      li.appendChild(form);
+      commList.appendChild(li);
+    });
+  }
+
+  loadData();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+from app.main import app, professionals, appointments
+
+client = TestClient(app)
+
+def test_list_professionals():
+    response = client.get("/professionals")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == len(professionals)
+    assert data[0]["name"] == professionals[0].name
+
+def test_create_appointment():
+    appointments.clear()
+    payload = {"client_name": "山田太郎", "scheduled_time": "2025-01-01T10:00:00"}
+    response = client.post("/professionals/1/appointments", json=payload)
+    assert response.status_code == 201
+    assert len(appointments) == 1
+    assert appointments[0].client_name == "山田太郎"
+
+def test_list_columns():
+    response = client.get("/columns")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_list_communities_and_post_message():
+    response = client.get("/communities")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    message = {"message": "こんにちは"}
+    response_post = client.post("/communities/1/messages", json=message)
+    assert response_post.status_code == 201
+
+
+def test_index_served():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]


### PR DESCRIPTION
## Summary
- serve static frontend through FastAPI to demo professionals, columns, communities and appointment booking
- document how to run the demo site
- add test ensuring frontend index is reachable

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6895be536b1c8320a2e0f67d30a163f3